### PR TITLE
Add tokenizers to primary label

### DIFF
--- a/resources/schema/schema.xml
+++ b/resources/schema/schema.xml
@@ -60,6 +60,15 @@
 
     <!-- hpo plain language: HPO primary label -->
     <field name="label" type="string" required="true" multiValued="false" indexed="true" stored="true"></field>
+    <!--A StandardTokenized version of label.-->
+    <field name="label_std" type="text_std" required="false" multiValued="true" indexed="true" stored="true"></field>
+    <!--A EdgeNGram version of label.-->
+    <field name="label_eng" type="text_eng" required="false" multiValued="true" indexed="true" stored="true"></field>
+    <!--A Keyword version of label.-->
+    <field name="label_kw" type="text_kw" required="false" multiValued="true" indexed="true" stored="true"></field>
+    <copyField source="label" dest="label_std"></copyField>
+    <copyField source="label" dest="label_eng"></copyField>
+    <copyField source="label" dest="label_kw"></copyField>
 
     <!-- Exact synonyms. -->
     <field name="exact_synonym" type="string" required="false" multiValued="true" indexed="true" stored="true"></field>


### PR DESCRIPTION
Adds tokenizers to primary label (standard, keyword, n-gram) so that these can be searched on. See https://github.com/OCTRI/phenotypr-body/issues/75#issuecomment-414003797